### PR TITLE
Hide not displayed references per default; fixes #13

### DIFF
--- a/app/Controllers/Reference.php
+++ b/app/Controllers/Reference.php
@@ -32,26 +32,24 @@ class Reference extends ControllerAbstract
             $_SESSION['reference']['orderby'] = $get['orderby'];
         }
 
-       // retrieve data from model
-        $references = ReferenceModel::where('is_displayed', true)
-                           ->orderBy(
-                               $_SESSION['reference']['orderby'],
-                               $_SESSION['reference']['sort']
-                           )
-                           ->paginate(15);
+        // retrieve data from model
+        $references = ReferenceModel::active()->orderBy(
+            $_SESSION['reference']['orderby'],
+            $_SESSION['reference']['sort']
+        )->paginate(15);
 
         $references->setPath($this->container->get('settings')['baseurl']."reference");
 
        // render in twig view
         $this->render($this->container->project->pathFor('reference.html.twig'), [
-         'total'      => ReferenceModel::where('is_displayed', true)->count(),
-         'class'      => 'reference',
-         'showmodal'  => isset($get['showmodal']),
-         'uuid'       => isset($get['uuid']) ? $get['uuid'] : '',
-         'references' => $references,
-         'pagination' => $references->appends($_GET)->render(),
-         'orderby'    => $_SESSION['reference']['orderby'],
-         'sort'       => $_SESSION['reference']['sort']
+            'total'         => ReferenceModel::active()->count(),
+            'class'         => 'reference',
+            'showmodal'     => isset($get['showmodal']),
+            'uuid'          => isset($get['uuid']) ? $get['uuid'] : '',
+            'references'    => $references,
+            'pagination'    => $references->appends($_GET)->render(),
+            'orderby'       => $_SESSION['reference']['orderby'],
+            'sort'          => $_SESSION['reference']['sort']
         ]);
     }
 

--- a/app/Controllers/Telemetry.php
+++ b/app/Controllers/Telemetry.php
@@ -30,10 +30,10 @@ class Telemetry extends ControllerAbstract
          'nb'  => (string) Number::n($raw_nb_tel_entries)->round(2)->getSuffixNotation()
         ];
 
-      // retrieve nb of reference entries
-        $raw_nb_ref_entries = ReferenceModel
-         ::where('created_at', '>=', DB::raw("NOW() - INTERVAL '$years YEAR'"))
-         ->count();
+        // retrieve nb of reference entries
+        $raw_nb_ref_entries = ReferenceModel::active()
+            ->where('created_at', '>=', DB::raw("NOW() - INTERVAL '$years YEAR'"))
+            ->count();
         $nb_ref_entries = [
          'raw' => $raw_nb_ref_entries,
          'nb'  => (string) Number::n($raw_nb_ref_entries)->round(2)->getSuffixNotation()
@@ -89,7 +89,7 @@ class Telemetry extends ControllerAbstract
        // TODO
 
        // retrieve reference country
-        $references_countries = ReferenceModel::select(
+        $references_countries = ReferenceModel::active()->select(
             DB::raw("country as cca2, count(*) as total")
         )
          ->where('created_at', '>=', DB::raw("NOW() - INTERVAL '$years YEAR'"))

--- a/app/Models/Reference.php
+++ b/app/Models/Reference.php
@@ -6,4 +6,15 @@ class Reference extends \Illuminate\Database\Eloquent\Model
     protected $guarded = [
       'is_displayed'
     ];
+    /**
+     * Scope a query to only include references that can be displayed.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query Query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeActive($query)
+    {
+        return $query->where('is_displayed', '=', true);
+    }
 }


### PR DESCRIPTION
This changes the default query to exclude not displayed references per default.

Note: it seems this is not possible to show not displayed ones; even if we want to (ie. from a future admin ui) 