### PR TITLE
detect also PostgreSQL db engine

### DIFF
--- a/app/Controllers/Telemetry.php
+++ b/app/Controllers/Telemetry.php
@@ -243,6 +243,7 @@ class Telemetry extends ControllerAbstract
             // retrieve db engine
             $db_engines = TelemetryModel::select(
                 DB::raw("CASE
+                            WHEN UPPER(db_engine) LIKE 'POSTGRE%' THEN 'PostgreSQL'
                             WHEN UPPER(db_engine) LIKE 'MARIA%' THEN 'MariaDB'
                             WHEN UPPER(db_engine) LIKE 'MYSQL%' THEN 'MySQL'
                             ELSE 'MySQL'


### PR DESCRIPTION
All db engines are recognised as 'MariaDB' or 'MySQL'. This change adds 'PostgreSQL' detection.