### PR TITLE
Fix modal opening

### DIFF
--- a/app/Templates/default/reference.html.twig
+++ b/app/Templates/default/reference.html.twig
@@ -238,9 +238,8 @@ $(document).ready(function() {
         width: '100%',
     });
 
-
-   // if get parameter showmodal is present, show the corresponding modal
    {% if showmodal == true %}
+   // if get parameter showmodal is present, show the corresponding modal
    $("#register_reference").modal('show');
    {% endif %}
 });


### PR DESCRIPTION
There is an issue, probably related to Twig trimming logic, that breaks the javascript script of the `Reference` page.

Here is the generated code:
```
<script type="text/javascript">

$(document).ready(function() {
    $("#countries_select").select2({
        templateSelection: formatState,
        templateResult: formatState,
        placeholder: "Country",
        width: '100%',
        dropdownParent: $('#register_reference')
    });

    $("#filter_country").select2({
        templateSelection: formatState,
        templateResult: formatState,
        width: '100%',
    });


   // if get parameter showmodal is present, show the corresponding modal   $("#register_reference").modal('show');});
</script>    </body>
``

As you can see, `$("#register_reference").modal('show');});` is not output on a new line, and so is considered as a comment.